### PR TITLE
Play audios

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Shop from "./pages/shop/Shop";
 import Home from "./pages/home/Home";
 import Cart from "./pages/cart/Cart";
-import Showcase from "./pages/showcase/Showcase";
+import Showcase from "./pages/showcase/Piece";
 import Checkout from "./pages/checkout/Checkout";
 import ErrorPage from "./pages/ErrorPage";
 import { PieceService } from "./services/PieceService";

--- a/frontend/src/components/ShowcaseSection.tsx
+++ b/frontend/src/components/ShowcaseSection.tsx
@@ -13,6 +13,16 @@ import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { PieceDTO } from "../dtos/dtos";
 
+function formatTime(time: number) {
+  const minutes = Math.floor(time / 60);
+  const seconds = Math.floor(time % 60);
+  if (seconds > 9) {
+    return `${minutes}:${seconds}`;
+  } else {
+    return `${minutes}:0${seconds}`;
+  }
+}
+
 const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [quantity, setQuantity] = useState<number>(1);

--- a/frontend/src/components/ShowcaseSection.tsx
+++ b/frontend/src/components/ShowcaseSection.tsx
@@ -14,9 +14,11 @@ import { toast } from "react-toastify";
 import { PieceDTO } from "../dtos/dtos";
 
 const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [quantity, setQuantity] = useState(1);
+  const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const [quantity, setQuantity] = useState<number>(1);
   const [progress, setProgress] = useState("0:01");
+  const [duration, setDuration] = useState<number>(0);
+  const [audioReady, setAudioReady] = useState<boolean>(false);
   const audio = useRef(
     new Audio(
       "../../public/audios/" +

--- a/frontend/src/components/ShowcaseSection.tsx
+++ b/frontend/src/components/ShowcaseSection.tsx
@@ -9,7 +9,7 @@ import {
   IconPlayerPlayFilled,
   IconUsers,
 } from "@tabler/icons-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 import { PieceDTO } from "../dtos/dtos";
 
@@ -17,8 +17,21 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [quantity, setQuantity] = useState(1);
   const [progress, setProgress] = useState("0:01");
+  const audio = useRef(
+    new Audio(
+      "../../public/audios/" +
+        piece.title.replace(/ /g, "-").toLowerCase() +
+        ".mp3",
+    ),
+  );
 
-  const handlePlay = () => {
+  // TODO: this is not pausing
+  const handlePlayPauseClick = () => {
+    if (isPlaying) {
+      audio.current.pause();
+    } else {
+      audio.current.play();
+    }
     setIsPlaying(!isPlaying);
   };
 
@@ -91,12 +104,12 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
             />
             {isPlaying ? (
               <IconPlayerPauseFilled
-                onClick={handlePlay}
+                onClick={handlePlayPauseClick}
                 className="absolute z-30 text-primary size-28 hover:text-reallyWhite cursor-pointer"
               />
             ) : (
               <IconPlayerPlayFilled
-                onClick={handlePlay}
+                onClick={handlePlayPauseClick}
                 className="absolute z-30 text-primary size-28 hover:text-reallyWhite cursor-pointer"
               />
             )}

--- a/frontend/src/components/showcase/ShowcaseSection.css
+++ b/frontend/src/components/showcase/ShowcaseSection.css
@@ -1,0 +1,74 @@
+.main-container {
+  @apply min-h-screen flex flex-row mx-52 mt-24;
+}
+
+.information-container {
+  @apply flex flex-col w-full h-screen  z-10  text-textGray justify-between py-3;
+}
+
+.title-description-container {
+  @apply flex flex-col gap-2;
+}
+.title {
+  @apply text-7xl text-white;
+}
+
+.description {
+  @apply text-textGray text-lg font-light w-4/5;
+}
+
+.attributes-container {
+  @apply flex flex-col gap-4 text-3xl font-light;
+}
+
+.attributes {
+  @apply flex flex-row gap-4 items-center;
+}
+
+.electronics-check {
+  @apply text-primary size-6;
+}
+
+.music-cart-container {
+  @apply flex flex-col  justify-between text-2xl font-medium text-textGray w-full  gap-4 h-screen py-3;
+}
+
+.image-container {
+  @apply relative flex items-center justify-center;
+}
+
+.art {
+  @apply z-10 rounded-full w-[550px] h-[550px] object-cover;
+}
+
+.record-overlay {
+  @apply absolute  z-20 w-[550px] h-[550px] opacity-30 object-cover;
+}
+
+.player-icon {
+  @apply absolute z-30 text-primary size-28 hover:text-reallyWhite cursor-pointer;
+}
+
+.progressbar-container {
+  @apply relative w-full h-1  bg-reallyWhite rounded;
+}
+
+.progressbar {
+  @apply absolute h-full bg-primary rounded;
+}
+
+.progress-fraction {
+  @apply absolute -top-6 right-0 text-white text-sm;
+}
+
+.cart-section {
+  @apply flex flex-row justify-between text-2xl;
+}
+
+.primary-button {
+  @apply bg-primary py-6;
+}
+
+.price-text {
+  @apply text-6xl text-white;
+}

--- a/frontend/src/components/showcase/ShowcaseSection.tsx
+++ b/frontend/src/components/showcase/ShowcaseSection.tsx
@@ -134,8 +134,8 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
             )}
           </div>
 
-          {/* Progress bar */}
           <div className="progressbar-container">
+            {/* TODO: this is not working... needs to probably use more complay audio controls */}
             <div
               className="progressbar"
               style={{

--- a/frontend/src/components/showcase/ShowcaseSection.tsx
+++ b/frontend/src/components/showcase/ShowcaseSection.tsx
@@ -104,10 +104,10 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
           </div>
         </div>
 
-        <div className="flex flex-col  justify-between text-2xl font-medium text-textGray w-full  gap-4 h-screen py-3">
-          <div className="relative flex items-center justify-center ">
+        <div className="music-cart-container">
+          <div className="image-container">
             <img
-              className="z-10 rounded-full w-[550px] h-[550px] object-cover"
+              className="art"
               src={
                 "../../public/albums/" +
                 piece.title.replace(/ /g, "-").toLowerCase() +
@@ -117,48 +117,48 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
             />
             <img
               loading="lazy"
-              className="absolute  z-20 w-[550px] h-[550px] opacity-30 object-cover"
+              className="record-overlay"
               src="/record_overlay.png"
               alt="Music Album Overlay"
             />
             {isPlaying ? (
               <IconPlayerPauseFilled
                 onClick={handlePlayPauseClick}
-                className="absolute z-30 text-primary size-28 hover:text-reallyWhite cursor-pointer"
+                className="player-icon"
               />
             ) : (
               <IconPlayerPlayFilled
                 onClick={handlePlayPauseClick}
-                className="absolute z-30 text-primary size-28 hover:text-reallyWhite cursor-pointer"
+                className="player-icon"
               />
             )}
           </div>
 
           {/* Progress bar */}
-          <div className="relative w-full h-1  bg-reallyWhite rounded">
+          <div className="progressbar-container">
             <div
-              className="absolute h-full bg-primary rounded"
+              className="progressbar"
               style={{
                 width: `${(audio.current.currentTime / audio.current.duration) * 100}%`,
               }}
             ></div>
-            <div className="absolute -top-6 right-0 text-white text-sm">
+            <div className="progress-fraction">
               {progress + " "} /{" " + formatTime(audio.current.duration)}
             </div>
           </div>
 
           <div>
-            <div className="flex flex-row justify-between text-2xl ">
-              <div className="button bg-primary py-6">
+            <div className="cart-section">
+              <div className="button primary-button">
                 Quantity {quantity} <IconChevronDown />
               </div>
-              <p className="text-6xl text-white">${piece.price}</p>
+              <p className="price-text">${piece.price}</p>
             </div>
             <a
               onClick={() => {
                 toast.success(piece.title + " Added to Cart");
               }}
-              className="button bg-primary py-6 "
+              className="button primary-button"
             >
               Add To Cart
             </a>

--- a/frontend/src/components/showcase/ShowcaseSection.tsx
+++ b/frontend/src/components/showcase/ShowcaseSection.tsx
@@ -134,18 +134,16 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
             )}
           </div>
 
-          <div>
-            {/* Progress bar */}
-            <div className="relative w-full h-1  bg-reallyWhite rounded">
-              <div
-                className="absolute h-full bg-primary rounded"
-                style={{
-                  width: `${(audio.current.currentTime / audio.current.duration) * 100}%`,
-                }}
-              ></div>
-              <div className="absolute -top-6 right-0 text-white text-sm">
-                {progress + " "} /{" " + formatTime(audio.current.duration)}
-              </div>
+          {/* Progress bar */}
+          <div className="relative w-full h-1  bg-reallyWhite rounded">
+            <div
+              className="absolute h-full bg-primary rounded"
+              style={{
+                width: `${(audio.current.currentTime / audio.current.duration) * 100}%`,
+              }}
+            ></div>
+            <div className="absolute -top-6 right-0 text-white text-sm">
+              {progress + " "} /{" " + formatTime(audio.current.duration)}
             </div>
           </div>
 

--- a/frontend/src/components/showcase/ShowcaseSection.tsx
+++ b/frontend/src/components/showcase/ShowcaseSection.tsx
@@ -9,10 +9,11 @@ import {
   IconPlayerPlayFilled,
   IconUsers,
 } from "@tabler/icons-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
-import { PieceDTO } from "../dtos/dtos";
+import { PieceDTO } from "../../dtos/dtos";
 
+// TODO: this is giving a weird pace to the size of some seconds
 function formatTime(time: number) {
   const minutes = Math.floor(time / 60);
   const seconds = Math.floor(time % 60);
@@ -26,16 +27,12 @@ function formatTime(time: number) {
 const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [quantity, setQuantity] = useState<number>(1);
-  const [progress, setProgress] = useState("0:01");
-  const [duration, setDuration] = useState<number>(0);
-  const [audioReady, setAudioReady] = useState<boolean>(false);
-  const audio = useRef(
-    new Audio(
-      "../../public/audios/" +
-        piece.title.replace(/ /g, "-").toLowerCase() +
-        ".mp3",
-    ),
-  );
+  const [progress, setProgress] = useState<string>("0:00");
+  const pieceAudio =
+    "../../public/audios/" +
+    piece.title.replace(/ /g, "-").toLowerCase() +
+    ".mp3";
+  const audio = useRef(new Audio(pieceAudio));
 
   // TODO: this is not pausing
   const handlePlayPauseClick = () => {
@@ -47,40 +44,50 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
     setIsPlaying(!isPlaying);
   };
 
+  useEffect(() => {
+    const handleTimeUpdate = () => {
+      setProgress(formatTime(audio.current.currentTime));
+    };
+
+    audio.current.addEventListener("timeupdate", handleTimeUpdate);
+
+    return () => {
+      audio.current.removeEventListener("timeupdate", handleTimeUpdate);
+    };
+  }, []);
+
   return (
     <>
-      <div className="min-h-screen  flex flex-row mx-52   mt-24">
-        <div className="flex flex-col w-full h-screen  z-10  text-textGray justify-between py-3">
-          <div className="flex flex-col gap-2">
-            <p className="text-7xl text-white">{piece.title}</p>
-            <span className="text-textGray text-lg font-light w-4/5  ">
-              {piece.description}
-            </span>
+      <div className="main-container">
+        <div className="information-container">
+          <div className="title-description-container">
+            <p className="title">{piece.title}</p>
+            <span className="description">{piece.description}</span>
           </div>
 
-          <div className="flex flex-col gap-4 text-3xl font-light">
-            <div className="flex flex-row gap-4 items-center">
+          <div className="attributes-container">
+            <div className="attributes">
               <IconCalendar /> {piece.yearComposed}
             </div>
 
-            <div className="flex flex-row gap-4 items-center">
+            <div className="attributes">
               <IconUsers /> {piece.numOfPlayers} Players
             </div>
 
-            <div className="flex flex-row gap-4 items-center">
+            <div className="attributes">
               <IconBrandSpeedtest /> {piece.difficultyGrade}{" "}
               {piece.difficultyGrade < 3 ? "Beginner" : "Advanced"}
             </div>
 
-            <div className="flex flex-row gap-4 items-center">
+            <div className="attributes">
               <IconClock /> {piece.timeLength} Minutes
             </div>
 
             <div className="flex flex-row gap-4 items-center">
               {piece.hasElectronics ? (
-                <IconCircleCheckFilled className="text-primary size-6" />
+                <IconCircleCheckFilled className="electronics-check" />
               ) : (
-                <IconCircleXFilled className="text-primary size-6" />
+                <IconCircleXFilled className="electronics-check" />
               )}
               Electronics
             </div>
@@ -132,10 +139,12 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
             <div className="relative w-full h-1  bg-reallyWhite rounded">
               <div
                 className="absolute h-full bg-primary rounded"
-                style={{ width: "2%" }}
+                style={{
+                  width: `${(audio.current.currentTime / audio.current.duration) * 100}%`,
+                }}
               ></div>
               <div className="absolute -top-6 right-0 text-white text-sm">
-                {progress} / {piece.timeLength}
+                {progress + " "} /{" " + formatTime(audio.current.duration)}
               </div>
             </div>
           </div>

--- a/frontend/src/components/showcase/ShowcaseSection.tsx
+++ b/frontend/src/components/showcase/ShowcaseSection.tsx
@@ -135,7 +135,7 @@ const ShowcaseSection = ({ piece: piece }: { piece: PieceDTO }) => {
           </div>
 
           <div className="progressbar-container">
-            {/* TODO: this is not working... needs to probably use more complay audio controls */}
+            {/* TODO: somehow need to make this choose where you are in the piece */}
             <div
               className="progressbar"
               style={{

--- a/frontend/src/pages/showcase/Piece.tsx
+++ b/frontend/src/pages/showcase/Piece.tsx
@@ -3,21 +3,21 @@ import Footer from "../../components/Footer";
 import Header from "../../components/Header";
 import SecondaryHeroSection from "../../components/SecondaryHeroSection";
 import SeperationSection from "../../components/SeperationSection";
-import ShowcaseSection from "../../components/ShowcaseSection";
+import ShowcaseSection from "../../components/showcase/ShowcaseSection";
 import { PieceDTO } from "../../dtos/dtos";
 
 const Shop = ({ piece }: { piece: PieceDTO }) => {
   return (
     <body className="flex flex-col  bg-black">
       <Header />
-      <SecondaryHeroSection
-        backdrop={true}
-        image={
-          "../../../public/albums/" +
-          piece.title.replace(/ /g, "-").toLowerCase() +
-          ".png"
-        }
-      />
+      {/* <SecondaryHeroSection */}
+      {/*   backdrop={true} */}
+      {/*   image={ */}
+      {/*     "../../../public/albums/" + */}
+      {/*     piece.title.replace(/ /g, "-").toLowerCase() + */}
+      {/*     ".png" */}
+      {/*   } */}
+      {/* /> */}
       <ShowcaseSection piece={piece} />
       <SeperationSection />
       <ContactSection />


### PR DESCRIPTION
audios are playing and pausing now. need to add: 
- bar to choose where you are in the piece
- some way to tune audio controls like volume
- the progress bar atm works nice, but you cant use it to choose where you are. there really isnt any way in general right now

i also moved the css into its own file to avoid clutter, and removed the secondary hero section for now. I had someone use it, and they said "what where is everything". I think just having the information be the first thing they see would be better. definitely open to suggestions.